### PR TITLE
golangci-lint: use the latest version available

### DIFF
--- a/.github/workflows/golint.yml
+++ b/.github/workflows/golint.yml
@@ -16,7 +16,7 @@ jobs:
           check-latest: true
       - name: Install golangci-lint
         run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.50.1
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin latest
       - name: Download .golangci.yml
         if:  ${{ hashFiles('.golangci.yml', '.golangci.yaml', '.golangci.toml', '.golangci.json') == '' }}
         run: |


### PR DESCRIPTION
This PR alters `golint.yml` so that it always uses the latest available version for `golangci-lint`.