### PR TITLE
Use golangci/golangci-lint-action when linting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,19 +29,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Setup Go
-        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+      - name: Lint dummy app
+        uses: golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837 # v6.5.0
         with:
-          go-version-file: go/go.mod
-          check-latest: true
-
-      - name: Install golangci-lint
-        run: |
-          curl -sSfL "https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh" | sh -s -- -b "$(go env GOPATH)/bin" v1.64.4
-
-      - name: Verify .golangci.yml
-        run: golangci-lint config verify -v --config .golangci.yml
-
-      - name: Lint the dummy application
-        working-directory: go
-        run: golangci-lint run -v --out-format github-actions --config ../.golangci.yml ./...
+          working-directory: go
+          version: latest
+          verify: true
+          args: --config=../.golangci.yml

--- a/.github/workflows/golint.yml
+++ b/.github/workflows/golint.yml
@@ -60,40 +60,17 @@ jobs:
         os: ${{ fromJson(needs.targets.outputs.json) }}
 
     steps:
-      - name: Checkout the workflows repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          path: workflows
-          ref: master
-          repository: azazeal/workflows
-
       - name: Checkout the source repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          path: src
           submodules: recursive
 
-      - name: Setup Go
-        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
-        with:
-          go-version-file: src/${{ inputs.go-version-file }}
-          cache-dependency-path: workflows/go/go.sum
-          check-latest: true
-
-      - name: Install golangci-lint
-        working-directory: workflows/go
-        run: |
-          curl -sSfL "https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh" | sh -s -- -b "$(go env GOPATH)/bin" v1.64.4
-
-      - name: Copy .golangci.yml (if required)
-        working-directory: src
+      - name: Configure the linter (if required)
         if:  ${{ hashFiles('.golangci.yml', '.golangci.yaml', '.golangci.toml', '.golangci.json') == '' }}
-        run: cp ../workflows/.golangci.yml .
+        run: curl -O https://raw.githubusercontent.com/azazeal/workflows/master/.golangci.yml
 
-      - name: Verify .golangci.yml
-        working-directory: src
-        run: golangci-lint config verify -v
-
-      - name: Run Linter
-        working-directory: src
-        run: golangci-lint run --out-format github-actions ./...
+      - name: Run linter
+        uses: golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837 # v6.5.0
+        with:
+          version: latest
+          verify: true


### PR DESCRIPTION
This PR refactors the build so it now uses the `golangci/golangci-lint-action` action when linting, instead of installing the linter manually.